### PR TITLE
Bump module versions. Add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform:install
+  - make terraform:get-plugins
+  - make terraform:get-modules
+  - make terraform:lint
+  - make terraform:validate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL = /bin/bash
+
+include $(shell curl --silent -o .build-harness "https://raw.githubusercontent.com/cloudposse/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform:install terraform:get-modules terraform:get-plugins terraform:lint terraform:validate

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module "domain" {
   source               = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=master"
   namespace            = "example"
   stage                = "dev"
-  name                 = "foobar"
+  name                 = "cluster"
   parent_zone_name     = "example.com"
   zone_name            = "$${name}.$${stage}.$${parent_zone_name}"
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# terraform-aws-route53-cluster-zone
+# terraform-aws-route53-cluster-zone [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-route53-cluster-zone.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-route53-cluster-zone)
 
 Terraform module to easily define consistent cluster domains on `Route53`.
 

--- a/examples/complete/.gitignore
+++ b/examples/complete/.gitignore
@@ -1,0 +1,2 @@
+*.tfstate
+*.tfstate.backup

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,8 @@
+module "domain" {
+  source           = "../../"
+  namespace        = "example"
+  stage            = "dev"
+  name             = "cluster"
+  parent_zone_name = "example.com"
+  zone_name        = "$${name}.$${stage}.$${parent_zone_name}"
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,0 +1,19 @@
+output "parent_zone_id" {
+  value = "${module.domain.parent_zone_id}"
+}
+
+output "parent_zone_name" {
+  value = "${module.domain.parent_zone_name}"
+}
+
+output "zone_id" {
+  value = "${module.domain.zone_id}"
+}
+
+output "zone_name" {
+  value = "${module.domain.zone_name}"
+}
+
+output "fqdn" {
+  value = "${module.domain.fqdn}"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,11 @@
-# Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 data "template_file" "zone_name" {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "label" {
 }
 
 data "template_file" "zone_name" {
-  template = "${replace(var.zone_name, "$$", "$")}"
+  template = "${replace(var.zone_name, "$$$$", "$")}"
 
   vars {
     namespace        = "${var.namespace}"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "label" {
 }
 
 data "template_file" "zone_name" {
-  template = "${replace(var.zone_name, "$$$$", "$")}"
+  template = "${replace(var.zone_name, "$$", "$")}"
 
   vars {
     namespace        = "${var.namespace}"

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "parent_zone_name" {
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+  description = "Delimiter to be used between `name`, `namespace`, `stage`, `attributes`"
 }
 
 variable "attributes" {
@@ -31,5 +31,5 @@ variable "attributes" {
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
+  description = "Additional tags (e.g. map('BusinessUnit','XYZ')"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,20 @@ variable "parent_zone_name" {
   default = ""
 }
 
-variable "ttl" {
-  default = "300"
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }


### PR DESCRIPTION
## what
* Bumped `terraform-null-label` version to `0.3.1`
* Added `TravisCI`

## why
* Old version requires `terraform fmt`
* To monitor build and repo status

