### PR TITLE
Add attributes and region as template parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -179,7 +178,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,8 @@ module "label" {
   enabled    = "${var.enabled}"
 }
 
+data "aws_region" "default" {}
+
 data "template_file" "zone_name" {
   count    = "${var.enabled == "true" ? 1 : 0}"
   template = "${replace(var.zone_name, "$$$$", "$")}"
@@ -20,6 +22,7 @@ data "template_file" "zone_name" {
     id               = "${module.label.id}"
     attributes       = "${module.label.attributes}"
     parent_zone_name = "${join("", null_resource.parent.*.triggers.zone_name)}"
+    region           = "${data.aws_region.default.name}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ data "template_file" "zone_name" {
     name             = "${var.name}"
     stage            = "${var.stage}"
     id               = "${module.label.id}"
+    attributes       = "${module.label.attributes}"
     parent_zone_name = "${join("", null_resource.parent.*.triggers.zone_name)}"
   }
 }


### PR DESCRIPTION
## what
* Support `attributes` as a template variable

## why
* Add ability to disambiguate hostnames using the optional `attributes` parameter.

## use-case

```
module "domain" {
  source               = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=master"
  namespace            = "example"
  stage                = "dev"
  name                 = "cluster"
  parent_zone_name     = "example.com"
  zone_name            = "$${name}-$${attributes}.$${region}.$${stage}.$${parent_zone_name}"
}
```
