### PR TITLE
fix: race condition when parent zone isn't created

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Available targets:
 | Name | Version |
 |------|---------|
 | aws | ~> 2.0 |
-| null | ~> 2.0 |
 | template | ~> 2.0 |
 
 ## Inputs
@@ -303,8 +302,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Valeriy][drama17_avatar]][drama17_homepage]<br/>[Valeriy][drama17_homepage] |
-|---|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Valeriy][drama17_avatar]][drama17_homepage]<br/>[Valeriy][drama17_homepage] | [![Vladimir Syromyatnikov][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir Syromyatnikov][SweetOps_homepage] |
+|---|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
@@ -314,6 +313,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [drama17_homepage]: https://github.com/drama17
   [drama17_avatar]: https://img.cloudposse.com/150x150/https://github.com/drama17.png
+  [SweetOps_homepage]: https://github.com/SweetOps
+  [SweetOps_avatar]: https://img.cloudposse.com/150x150/https://github.com/SweetOps.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -73,3 +73,5 @@ contributors:
     github: "aknysh"
   - name: "Valeriy"
     github: "drama17"
+  - name: "Vladimir Syromyatnikov"
+    github: "SweetOps"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,7 +12,6 @@
 | Name | Version |
 |------|---------|
 | aws | ~> 2.0 |
-| null | ~> 2.0 |
 | template | ~> 2.0 |
 
 ## Inputs

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,10 +1,10 @@
 output "parent_zone_id" {
-  value       = join("", null_resource.parent.*.triggers.zone_id)
+  value       = join("", data.aws_route53_zone.parent_zone.*.zone_id)
   description = "ID of the hosted zone to contain this record"
 }
 
 output "parent_zone_name" {
-  value       = join("", null_resource.parent.*.triggers.zone_name)
+  value       = join("", data.aws_route53_zone.parent_zone.*.name)
   description = "Name of the hosted zone to contain this record"
 }
 


### PR DESCRIPTION
## What

it's fix for the one of most popular terraform error when using counts: 

```
 count cannot be computed
```

### steps to reproduce

```hcl

resource "aws_route53_zone" "customer_deploy_parent_zone" {
  name = "cdp.sweetops.net"
  tags = module.customer_deploy_label.tags
}

module "customer_deploy_aws_domain" {
  source         = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-zone.git?ref=tags/0.4.0"
  namespace      = terraform.workspace
  stage          = "ci"
  name           = "customer"
  attributes     = ["deploy"]
  parent_zone_id = aws_route53_zone.customer_deploy_parent_zone.zone_id
  zone_name      = format("%s.%s", "ci", aws_route53_zone.customer_deploy_parent_zone.name)
}
```
