### PR TITLE
feat: allow overriding SOA and NS DNS record TTL

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_route53_record" "ns" {
   zone_id = join("", data.aws_route53_zone.parent_zone.*.zone_id)
   name    = join("", aws_route53_zone.default.*.name)
   type    = "NS"
-  ttl     = "60"
+  ttl     = var.ns_record_ttl
 
   records = [
     aws_route53_zone.default[0].name_servers[0],
@@ -54,7 +54,7 @@ resource "aws_route53_record" "soa" {
   zone_id         = join("", aws_route53_zone.default.*.id)
   name            = join("", aws_route53_zone.default.*.name)
   type            = "SOA"
-  ttl             = "30"
+  ttl             = var.soa_record_ttl
 
   records = [
     format("%s. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400", aws_route53_zone.default[0].name_servers[0])

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ data "template_file" "zone_name" {
 
   vars = {
     namespace        = module.this.namespace
+    tenant           = module.this.tenant
     environment      = module.this.environment
     name             = module.this.name
     stage            = module.this.stage

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,15 @@ variable "parent_zone_record_enabled" {
   default     = true
   description = "Whether to create the NS record on the parent zone. Useful for creating a cluster zone across accounts. `var.parent_zone_name` required if set to false."
 }
+
+variable "ns_record_ttl" {
+  type        = number
+  default     = 172800
+  description = "The time to live (TTL) of the nameserver Route53 record, in seconds."
+}
+
+variable "soa_record_ttl" {
+  type        = number
+  default     = 86400
+  description = "The time to live (TTL) of the start of authority Route53 record, in seconds."
+}


### PR DESCRIPTION
## what
* Provide variables to configure TTL for SOA and NS records
* Change default values of TTL for NS from 30 seconds to 2 days (172800 seconds)
* Change default values of TTL for SOA from 60 seconds to 1 day (86400 seconds)
* Also added the `tenant` context variable to the zone name template - maybe someone will need it :)

## why
These values were hardcoded and with too small default values. DNS is supposed to be a cache, and having a low TTL of records like NS or SOA contradicts that idea.

AWS defaults for TTL:
* NS - 172800
* SOA - 900

## references
Closes #46 

