### PR TITLE
feat: updates to use `replace` function instead of `template` provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,13 @@ Available targets:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | >= 2.0 |
+| <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 
@@ -288,7 +287,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 
@@ -157,7 +156,6 @@ Available targets:
 | [aws_route53_zone.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.parent_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [template_file.zone_name](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Available targets:
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Zone name | `string` | `"${name}.${stage}.$${parent_zone_name}"` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Zone name | `string` | `"${name}.${stage}.${parent_zone_name}"` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,7 +12,6 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 
@@ -29,7 +28,6 @@
 | [aws_route53_zone.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.parent_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [template_file.zone_name](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,14 +6,13 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | >= 2.0 |
+| <a name="provider_template"></a> [template](#provider\_template) | n/a |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -54,7 +54,7 @@
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Zone name | `string` | `"${name}.${stage}.$${parent_zone_name}"` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Zone name | `string` | `"${name}.${stage}.${parent_zone_name}"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_route53_zone" "default" {
     "$$$name", module.this.name),
     "$$$stage", module.this.stage),
     "$$$id", module.this.id),
-    "$$$attributes", module.this.attributes),
+    "$$$attributes", join(module.this.delimiter, module.this.attributes)),
     "$$$parent_zone_name", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)),
   "$$$region", data.aws_region.default.name)
 

--- a/main.tf
+++ b/main.tf
@@ -11,22 +11,6 @@ data "aws_route53_zone" "parent_zone" {
   name    = var.parent_zone_name
 }
 
-data "template_file" "zone_name" {
-  count    = local.enabled
-  template = replace(var.zone_name, "$$", "$")
-
-  vars = {
-    namespace        = module.this.namespace
-    environment      = module.this.environment
-    name             = module.this.name
-    stage            = module.this.stage
-    id               = module.this.id
-    attributes       = join(module.this.delimiter, module.this.attributes)
-    parent_zone_name = coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)
-    region           = data.aws_region.default.name
-  }
-}
-
 resource "aws_route53_zone" "default" {
   count = local.enabled
   name  = join("", data.template_file.zone_name.*.rendered)
@@ -34,11 +18,21 @@ resource "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "ns" {
-  count   = local.parent_zone_record_enabled
-  zone_id = join("", data.aws_route53_zone.parent_zone.*.zone_id)
-  name    = join("", aws_route53_zone.default.*.name)
-  type    = "NS"
-  ttl     = "60"
+  count = local.parent_zone_record_enabled
+  # https://github.com/hashicorp/terraform/issues/26838#issuecomment-840022506
+  zone_id = replace(replace(replace(replace(replace(replace(replace(replace(var.zone_name,
+    "$$$namespace", module.this.namespace),
+    "$$$environment", module.this.environment),
+    "$$$name", module.this.name),
+    "$$$stage", module.this.stage),
+    "$$$id", module.this.id),
+    "$$$attributes", module.this.attributes),
+    "$$$parent_zone_name", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)),
+  "$$$region", data.aws_region.default.name)
+
+  name = join("", aws_route53_zone.default.*.name)
+  type = "NS"
+  ttl  = "60"
 
   records = [
     aws_route53_zone.default[0].name_servers[0],

--- a/main.tf
+++ b/main.tf
@@ -16,14 +16,14 @@ resource "aws_route53_zone" "default" {
 
   # https://github.com/hashicorp/terraform/issues/26838#issuecomment-840022506
   name = replace(replace(replace(replace(replace(replace(replace(replace(var.zone_name,
-    "$$namespace", module.this.namespace),
-    "$$environment", module.this.environment),
-    "$$name", module.this.name),
-    "$$stage", module.this.stage),
-    "$$id", module.this.id),
-    "$$attributes", join(module.this.delimiter, module.this.attributes)),
-    "$$parent_zone_name", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)),
-  "$$region", data.aws_region.default.name)
+    "$${namespace}", module.this.namespace),
+    "$${environment}", module.this.environment),
+    "$${name}", module.this.name),
+    "$${stage}", module.this.stage),
+    "$${id}", module.this.id),
+    "$${attributes}", join(module.this.delimiter, module.this.attributes)),
+    "$${parent_zone_name}", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)),
+  "$${region}", data.aws_region.default.name)
 
   tags = module.this.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -16,14 +16,14 @@ resource "aws_route53_zone" "default" {
 
   # https://github.com/hashicorp/terraform/issues/26838#issuecomment-840022506
   name = replace(replace(replace(replace(replace(replace(replace(replace(var.zone_name,
-    "$$$namespace", module.this.namespace),
-    "$$$environment", module.this.environment),
-    "$$$name", module.this.name),
-    "$$$stage", module.this.stage),
-    "$$$id", module.this.id),
-    "$$$attributes", join(module.this.delimiter, module.this.attributes)),
-    "$$$parent_zone_name", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)),
-  "$$$region", data.aws_region.default.name)
+    "$$namespace", module.this.namespace),
+    "$$environment", module.this.environment),
+    "$$name", module.this.name),
+    "$$stage", module.this.stage),
+    "$$id", module.this.id),
+    "$$attributes", join(module.this.delimiter, module.this.attributes)),
+    "$$parent_zone_name", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)),
+  "$$region", data.aws_region.default.name)
 
   tags = module.this.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "zone_name" {
   type        = string
-  default     = "$$${name}.$$${stage}.$$${parent_zone_name}"
+  default     = "$${name}.$${stage}.$$${parent_zone_name}"
   description = "Zone name"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "zone_name" {
   type        = string
-  default     = "$${name}.$${stage}.$$${parent_zone_name}"
+  default     = "$${name}.$${stage}.$${parent_zone_name}"
   description = "Zone name"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"


### PR DESCRIPTION
## what
* remove unused template provider

## why
* template provider does not have darwin/arm64 binary, modules including it don't work on m1 mac.

