### PR TITLE
don't fail if parent_zone_name is not provided

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,4 +1,4 @@
-region = "us-west-1"
+region = "us-east-2"
 
 namespace = "eg"
 

--- a/examples/without_parent_zone/context.tf
+++ b/examples/without_parent_zone/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/without_parent_zone/fixtures.us-east-2.tfvars
+++ b/examples/without_parent_zone/fixtures.us-east-2.tfvars
@@ -1,4 +1,4 @@
-region = "us-west-1"
+region = "us-east-2"
 
 namespace = "eg"
 

--- a/examples/without_parent_zone/fixtures.us-east-2.tfvars
+++ b/examples/without_parent_zone/fixtures.us-east-2.tfvars
@@ -4,4 +4,6 @@ namespace = "eg"
 
 stage = "test"
 
-name = "testing.cloudposse.co"
+name = "hosted_zone_no_parent_record"
+
+zone_name = "testing.cloudposse.co"

--- a/examples/without_parent_zone/fixtures.us-west-1.tfvars
+++ b/examples/without_parent_zone/fixtures.us-west-1.tfvars
@@ -1,0 +1,7 @@
+region = "us-west-1"
+
+namespace = "eg"
+
+stage = "test"
+
+name = "testing.cloudposse.co"

--- a/examples/without_parent_zone/main.tf
+++ b/examples/without_parent_zone/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "domain" {
-  source           = "../../"
-  context          = module.this.context
-  zone_name        = "$${name}"
+  source    = "../../"
+  context   = module.this.context
+  zone_name = "$${name}"
 }

--- a/examples/without_parent_zone/main.tf
+++ b/examples/without_parent_zone/main.tf
@@ -5,6 +5,6 @@ provider "aws" {
 module "domain" {
   source                     = "../../"
   context                    = module.this.context
-  zone_name                  = "$${name}"
+  zone_name                  = var.zone_name
   parent_zone_record_enabled = false
 }

--- a/examples/without_parent_zone/main.tf
+++ b/examples/without_parent_zone/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "domain" {
-  source    = "../../"
-  context   = module.this.context
-  zone_name = "$${name}"
+  source                     = "../../"
+  context                    = module.this.context
+  zone_name                  = "$${name}"
+  parent_zone_record_enabled = false
 }

--- a/examples/without_parent_zone/main.tf
+++ b/examples/without_parent_zone/main.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = var.region
+}
+
+module "domain" {
+  source           = "../../"
+  context          = module.this.context
+  zone_name        = "$${name}"
+}

--- a/examples/without_parent_zone/outputs.tf
+++ b/examples/without_parent_zone/outputs.tf
@@ -1,0 +1,19 @@
+output "parent_zone_id" {
+  value = module.domain.parent_zone_id
+}
+
+output "parent_zone_name" {
+  value = module.domain.parent_zone_name
+}
+
+output "zone_id" {
+  value = module.domain.zone_id
+}
+
+output "zone_name" {
+  value = module.domain.zone_name
+}
+
+output "fqdn" {
+  value = module.domain.fqdn
+}

--- a/examples/without_parent_zone/variables.tf
+++ b/examples/without_parent_zone/variables.tf
@@ -2,4 +2,3 @@ variable "region" {
   type        = string
   description = "AWS region"
 }
-

--- a/examples/without_parent_zone/variables.tf
+++ b/examples/without_parent_zone/variables.tf
@@ -3,7 +3,3 @@ variable "region" {
   description = "AWS region"
 }
 
-variable "parent_zone_name" {
-  type        = string
-  description = "Parent zone name"
-}

--- a/examples/without_parent_zone/variables.tf
+++ b/examples/without_parent_zone/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "parent_zone_name" {
+  type        = string
+  description = "Parent zone name"
+}

--- a/examples/without_parent_zone/variables.tf
+++ b/examples/without_parent_zone/variables.tf
@@ -2,3 +2,8 @@ variable "region" {
   type        = string
   description = "AWS region"
 }
+
+variable "zone_name" {
+  type        = string
+  description = "Zone name"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   enabled                    = module.this.enabled ? 1 : 0
   parent_zone_record_enabled = var.parent_zone_record_enabled && module.this.enabled ? 1 : 0
+  parent_zone_name           = coalesce(var.parent_zone_name, "no_parent_zone_name")
 }
 
 data "aws_region" "default" {}
@@ -23,9 +24,8 @@ resource "aws_route53_zone" "default" {
     "$${stage}", module.this.stage),
     "$${id}", module.this.id),
     "$${attributes}", join(module.this.delimiter, module.this.attributes)),
-    "$${parent_zone_name}", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name)),
-    "$${region}", data.aws_region.default.name
-  )
+    "$${parent_zone_name}", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), local.parent_zone_name)),
+  "$${region}", data.aws_region.default.name)
 
   tags = module.this.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  enabled                    = module.this.enabled ? 1 : 0
-  parent_zone_record_enabled = var.parent_zone_record_enabled && module.this.enabled ? 1 : 0
-  parent_zone_name           = coalesce(var.parent_zone_name, "no_parent_zone_name")
+  enabled                    = module.this.enabled
+  parent_zone_record_enabled = var.parent_zone_record_enabled && module.this.enabled
+  zone_name                  = local.parent_zone_record_enabled ? var.zone_name : replace(var.zone_name, ".$${parent_zone_name}", "")
 }
 
 data "aws_region" "default" {}
@@ -24,7 +24,7 @@ resource "aws_route53_zone" "default" {
     "$${stage}", module.this.stage),
     "$${id}", module.this.id),
     "$${attributes}", join(module.this.delimiter, module.this.attributes)),
-    "$${parent_zone_name}", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), local.parent_zone_name)),
+    "$${parent_zone_name}", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name, "none")),
   "$${region}", data.aws_region.default.name)
 
   tags = module.this.tags

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,13 @@
 locals {
-  enabled                    = module.this.enabled
-  parent_zone_record_enabled = var.parent_zone_record_enabled && module.this.enabled
+  enabled                    = module.this.enabled ? 1 : 0
+  parent_zone_record_enabled = var.parent_zone_record_enabled && module.this.enabled ? 1 : 0
   zone_name                  = local.parent_zone_record_enabled ? var.zone_name : replace(var.zone_name, ".$${parent_zone_name}", "")
 }
 
 data "aws_region" "default" {}
 
 data "aws_route53_zone" "parent_zone" {
-  count   = local.parent_zone_record_enabled ? 1 : 0
+  count   = local.parent_zone_record_enabled
   zone_id = var.parent_zone_id
   name    = var.parent_zone_name
 }
@@ -31,7 +31,7 @@ resource "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "ns" {
-  count   = local.parent_zone_record_enabled ? 1 : 0
+  count   = local.parent_zone_record_enabled
   zone_id = join("", data.aws_route53_zone.parent_zone.*.zone_id)
   name    = join("", aws_route53_zone.default.*.name)
   type    = "NS"

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
 data "aws_region" "default" {}
 
 data "aws_route53_zone" "parent_zone" {
-  count   = local.parent_zone_record_enabled
+  count   = local.parent_zone_record_enabled ? 1 : 0
   zone_id = var.parent_zone_id
   name    = var.parent_zone_name
 }
@@ -31,7 +31,7 @@ resource "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "ns" {
-  count   = local.parent_zone_record_enabled
+  count   = local.parent_zone_record_enabled ? 1 : 0
   zone_id = join("", data.aws_route53_zone.parent_zone.*.zone_id)
   name    = join("", aws_route53_zone.default.*.name)
   type    = "NS"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   enabled                    = module.this.enabled ? 1 : 0
   parent_zone_record_enabled = var.parent_zone_record_enabled && module.this.enabled ? 1 : 0
-  zone_name                  = local.parent_zone_record_enabled ? var.zone_name : replace(var.zone_name, ".$${parent_zone_name}", "")
+  zone_name                  = local.parent_zone_record_enabled == 1 ? var.zone_name : replace(var.zone_name, ".$${parent_zone_name}", "")
 }
 
 data "aws_region" "default" {}

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_route53_zone" "default" {
   count = local.enabled
 
   # https://github.com/hashicorp/terraform/issues/26838#issuecomment-840022506
-  name = replace(replace(replace(replace(replace(replace(replace(replace(replace(var.zone_name,
+  name = replace(replace(replace(replace(replace(replace(replace(replace(replace(local.zone_name,
     "$${namespace}", module.this.namespace),
     "$${tenant}", module.this.tenant),
     "$${environment}", module.this.environment),

--- a/test/Makefile
+++ b/test/Makefile
@@ -30,7 +30,7 @@ clean:
 	[ "$(TEST_HARNESS_PATH)" == "/" ] || rm -rf $(TEST_HARNESS_PATH)
 
 ## Run all tests
-all: module examples/complete
+all: module examples/complete examples/without_parent_zone
 
 ## Run basic sanity checks against the module itself
 module: export TESTS ?= installed lint get-modules module-pinning get-plugins provider-pinning validate terraform-docs input-descriptions output-descriptions
@@ -40,4 +40,9 @@ module: deps
 ## Run tests against example
 examples/complete: export TESTS ?= installed lint get-modules get-plugins validate
 examples/complete: deps
+	$(call RUN_TESTS, ../$@)
+
+## Run tests against example without parent zone
+examples/without_parent_zone: export TESTS ?= installed lint get-modules get-plugins validate
+examples/without_parent_zone: deps
 	$(call RUN_TESTS, ../$@)

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -17,6 +17,7 @@ init:
 test: init
 	go mod download
 	go test -v -timeout 60m -run TestExamplesComplete
+	go test -v -timeout 60m -run TestExamplesWithoutParentZone
 
 ## Run tests in docker container
 docker/test:

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -16,7 +16,7 @@ func TestExamplesComplete(t *testing.T) {
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-west-1.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created

--- a/test/src/examples_without_parent_zone_test.go
+++ b/test/src/examples_without_parent_zone_test.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test the Terraform module in examples/without_parent_zone using Terratest.
+func TestExamplesWithoutParentZone(t *testing.T) {
+	t.Parallel()
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../../examples/without_parent_zone",
+		Upgrade:      true,
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Run `terraform output` to get the value of an output variable
+	zoneName := terraform.Output(t, terraformOptions, "zone_name")
+
+	expectedZoneName := "testing.cloudposse.co"
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, expectedZoneName, zoneName)
+}


### PR DESCRIPTION
## what
* because `var.parent_zone_name` is not required by the module as of #33, let the module work if it's not provided.

## why
* to use the module with a parent zone that is managed elsewhere,
```hcl
  parent_zone_record_enabled = false
  zone_name                  = "$${stage}.example.com
```
  INSTEAD OF...
```hcl
  parent_zone_name           = "example.com"
  parent_zone_record_enabled = false
  zone_name                  = "$${stage}.$${parent_zone_name}"
```

## alternatives considered
* main.tf:25
```hcl
    "$${parent_zone_name}", coalesce(join("", data.aws_route53_zone.parent_zone.*.name), var.parent_zone_name, "no_parent_zone_name")),
```
* I consider removing one of `var.parent_zone_id` or `var.parent_zone_name` because offering both can lead to conflict or confusion. If `var.parent_zone_id` is removed, then we can always rely on `var.parent_zone_name` instead of coalescing with the output of the `data.aws_route53_zone.parent_zone`
